### PR TITLE
fix: modify deprecated command

### DIFF
--- a/docs/setup/visible-simulation.en.md
+++ b/docs/setup/visible-simulation.en.md
@@ -12,7 +12,7 @@ sudo add-apt-repository ppa:graphics-drivers/ppa
 sudo apt update
 
 # Install drivers
-sudo ubuntu-drivers autoinstall
+sudo ubuntu-drivers install
 
 # Reboot
 reboot

--- a/docs/setup/visible-simulation.ja.md
+++ b/docs/setup/visible-simulation.ja.md
@@ -12,7 +12,7 @@ sudo add-apt-repository ppa:graphics-drivers/ppa
 sudo apt update
 
 # インストール
-sudo ubuntu-drivers autoinstall
+sudo ubuntu-drivers install
 
 # 再起動
 reboot


### PR DESCRIPTION
# 概要
環境構築ドキュメントでnvidia driverのインストールに使われている`sudo ubuntu-drivers autoinstall`が非推奨なので、推奨されている`sudo ubuntu-drivers install`に変更する。

![image](https://github.com/user-attachments/assets/6516bac9-3ba5-4f31-9c11-2d3dc510bbd0)
# 詳細
`sudo ubuntu-drivers autoinstall`を実行後、ネットワークに繋がらなくなる事象が発生した。原因は`sudo ubuntu-drivers autoinstall`を実行した際に、特定のカーネルモジュールがインストールされなくなることだった。
発生した事象としては以下のブログ記事と同様で、`sudo ubuntu-drivers autoinstall`を起因としてドライバ等が読み込まれない状態になった事例は他にもある模様。参加者が環境構築で無駄に苦労しないようにするために修正する。

[Nvidiaドライバをアップデートするとネットワークにつながらなくなる話](https://nttdocomo-developers.jp/entry/2024/12/07/090000_1)

# Test Performed
`sudo ubuntu-drivers autoinstall`の代わりに`sudo ubuntu-drivers install`を実行することで、カーネルモジュールが不足することなくnvidia driverをインストールすることができた。
